### PR TITLE
Updates docker pull to phpmyadmin:5.1.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     ports:
       - "3306:3306"
   phpmyadmin:
-    image: phpmyadmin/phpmyadmin:5.0.1
+    image: phpmyadmin/phpmyadmin:5.1.0
     restart: always
     environment:
       PMA_HOST: mysql-server


### PR DESCRIPTION
**This release adds full compatibility with PHP 8 and MySQL/MariaDB 5.5.**
- This allows for docker to pull a newer release of phpmyadmin.
- This does not pull the latest stable release automatically as docker only contains 5.1.1 as the latest.
- Optimizes initial startup on Debian clients.